### PR TITLE
Allow Capitalize to not throw if nothing is passed in

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,11 @@ function makeWptFyiUrl(path, params={}) {
 }
 
 function capitalize(str) {
-    return str && str[0].toUpperCase() + str.slice(1);
+    if (str) {
+        return str && str[0].toUpperCase() + str.slice(1);
+    } else {
+        return "";
+    }
 }
 
 class FetchError extends Error {


### PR DESCRIPTION
When wanting to see how many Firefox tests are failing we have a situation
where it tries to capitalize `undefined` which throws. This just makes sure
we pass back an empty string.